### PR TITLE
ci: Replace deprecated set-output with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       # some reason smh. here we use outputs instead
       - name: set output to deploy target
         id: set-output
-        run: echo "::set-output name=target::${{ env.TARGET }}"
+        run: echo "target=${{ env.TARGET }}" >> "$GITHUB_OUTPUT"
 
   # not sure if anyone wants this but I'm putting this here for those that don't
   # want to host their site. else the actions will show an annoying x whenever

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
     - uses: actions/first-interaction@v3
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: >-
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        issue_message: >-
           Thanks for submitting an issue! I'll check it at as soon as possible
           and get back to you.
-        pr-message: >-
+        pr_message: >-
           Thanks for submitting a PR. If the PR is a valid and passes
           all the checks , we will approve it soon. Have a great day !


### PR DESCRIPTION
The ::set-output workflow command is deprecated and will be disabled by GitHub. Write to the $GITHUB_OUTPUT environment file instead to keep the deploy target output working.